### PR TITLE
画像パスにAltがある場合と、解像度を指定しているときにパスが変更されないのを修正

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8152,7 +8152,7 @@ function replaceImagePaths(inputContent) {
     // Only replace image paths outside of code blocks
     for (let i = 0; i < parts.length; i++) {
         if (!parts[i].startsWith('```')) {
-            parts[i] = parts[i].replace(/!\[\]\((\/.*?)\)/g, `![](${githubRawUrl}$1)`);
+            parts[i] = parts[i].replace(/!\[(.*?)\]\((\/.*?)\)/g, `![$1](${githubRawUrl}$2)`);
         }
     }
     // Rejoin the markdown

--- a/dist/index.js
+++ b/dist/index.js
@@ -8152,6 +8152,7 @@ function replaceImagePaths(inputContent) {
     // Only replace image paths outside of code blocks
     for (let i = 0; i < parts.length; i++) {
         if (!parts[i].startsWith('```')) {
+            parts[i] = parts[i].replace(/!\[(.*?)\]\((.*?)\s*=\d+x\d*\)/g, `![$1]($2)`);
             parts[i] = parts[i].replace(/!\[(.*?)\]\((\/.*?)\)/g, `![$1](${githubRawUrl}$2)`);
         }
     }

--- a/scripts/lib/replace-image-paths.tsx
+++ b/scripts/lib/replace-image-paths.tsx
@@ -34,7 +34,7 @@ export function replaceImagePaths(inputContent: string): string {
   // Only replace image paths outside of code blocks
   for (let i = 0; i < parts.length; i++) {
     if (!parts[i].startsWith('```')) {
-      parts[i] = parts[i].replace(/!\[\]\((\/.*?)\)/g, `![](${githubRawUrl}$1)`)
+      parts[i] = parts[i].replace(/!\[(.*?)\]\((\/.*?)\)/g, `![$1](${githubRawUrl}$2)`);
     }
   }
 

--- a/scripts/lib/replace-image-paths.tsx
+++ b/scripts/lib/replace-image-paths.tsx
@@ -34,6 +34,7 @@ export function replaceImagePaths(inputContent: string): string {
   // Only replace image paths outside of code blocks
   for (let i = 0; i < parts.length; i++) {
     if (!parts[i].startsWith('```')) {
+      parts[i] = parts[i].replace(/!\[(.*?)\]\((.*?)\s*=\d+x\d*\)/g, `![$1]($2)`);
       parts[i] = parts[i].replace(/!\[(.*?)\]\((\/.*?)\)/g, `![$1](${githubRawUrl}$2)`);
     }
   }


### PR DESCRIPTION
初めまして。
大変便利で使わせていただいております！
アクションをローカルで試していたところ、以下二つの場合うまくパスの修正が行われませんでした。

### Alt が入っている場合
```
![サンプルページイメージ](/images/react-github-b6fb36b54a7e31/reactvite-github.png)
```

### 解像度している場合
```
![arduboy](https://upload.wikimedia.org/wikipedia/commons/b/b8/Arduboy_front_back.jpg =512x)
```

このPRで上記二つが解決されるはずです。
ただし、僕自身あまりこの分野で知見がない為、もし何かおかしければコメントで指摘いただけると幸いです！
