### PR TITLE
workflow例のインデントがズレている問題を修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,7 +59,7 @@ zenn 用の記事を GitHub にプッシュすると、自動的に qiita に記
         branches:
           - main
           - master
-        workflow_dispatch:
+      workflow_dispatch:
 
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can use this tool by following the steps below. Refer my [repo](https://gith
         branches:
           - main
           - master
-        workflow_dispatch:
+      workflow_dispatch:
 
     permissions:
       contents: write


### PR DESCRIPTION
はじめまして。
workflowを利用させていただく際に、ミス...と思われますものを発見しましたので、報告させていただきます。
間違っていましたら申し訳ありません。

修正内容といたしましては、`README.md`と`README.ja.md`ともに、
`workflow_dispatch:`のインデントを、`push:`配下より、`on:`配下へ変更いたしました。

本PRにより、workflow例をそのままコピー&ペーストすることで利用可能になります。

お手数ですがご確認をよろしくお願いいたします。